### PR TITLE
fix: 修复 vxe-table 类型定义无效的问题

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,21 +5,6 @@ import type ExcelJS from 'exceljs'
 let globalVxetable: VXETableCore
 let globalExcelJS: any
 
-declare module 'vxe-table' {
-  export namespace VxeTableDefines {
-    export interface ExtortSheetMethodParams {
-      workbook: ExcelJS.Workbook;
-      worksheet: ExcelJS.Worksheet;
-    }
-    export interface ColumnInfo {
-      _row: any;
-      _colSpan: number;
-      _rowSpan: number;
-      childNodes: VxeTableDefines.ColumnInfo[];
-    }
-  }
-}
-
 const defaultHeaderBackgroundColor = 'f8f8f9'
 const defaultCellFontColor = '606266'
 const defaultCellBorderStyle = 'thin'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference path='./vxe-table.d.ts' />
+
 import { VXETableCore } from 'vxe-table'
 
 /**

--- a/types/vxe-table.d.ts
+++ b/types/vxe-table.d.ts
@@ -1,0 +1,16 @@
+import type ExcelJS from 'exceljs'
+
+declare module 'vxe-table' {
+  export namespace VxeTableDefines {
+    export interface ExtortSheetMethodParams {
+      workbook: ExcelJS.Workbook;
+      worksheet: ExcelJS.Worksheet;
+    }
+    export interface ColumnInfo {
+      _row: any;
+      _colSpan: number;
+      _rowSpan: number;
+      childNodes: VxeTableDefines.ColumnInfo[];
+    }
+  }
+}


### PR DESCRIPTION
在 index.ts 文件中声明的 vxe-table 模块没有生效，独立 vxe-table.d.ts 在 index.d.ts 中引入
<img width="781" height="152" alt="PixPin_2025-09-10_16-20-15" src="https://github.com/user-attachments/assets/ae71880c-4018-4622-a197-e58809a59e2e" />